### PR TITLE
Adds undefined safety check to getPostCoverImageId

### DIFF
--- a/index.js
+++ b/index.js
@@ -199,6 +199,7 @@ function getPostId(post) {
 }
 
 function getPostCoverImageId(post) {
+	if (post.postmeta === undefined) return;
 	let postmeta = post.postmeta.find(postmeta => postmeta.meta_key[0] === '_thumbnail_id');
 	let id = postmeta ? postmeta.meta_value[0] : undefined;
 	return id;


### PR DESCRIPTION
Hello! Thanks for putting this package together and sharing it!

I grabbed this package and ran it against my export.xml file from my website ([edspencer.me.uk](https://edspencer.me.uk/)).

I hit an error:

```
ed@mini18:~/code/play/blog/node_modules/wordpress-export-to-markdown$ node index.js
events.js:183
      throw er; // Unhandled 'error' event
      ^

TypeError: Cannot read property 'find' of undefined
    at getPostCoverImageId (/home/ed/code/play/blog/node_modules/wordpress-export-to-markdown/index.js:202:31)
    at getItemsOfType.map.post (/home/ed/code/play/blog/node_modules/wordpress-export-to-markdown/index.js:128:19)
    at Array.map (<anonymous>)
    at collectPosts (/home/ed/code/play/blog/node_modules/wordpress-export-to-markdown/index.js:123:4)
    at processData (/home/ed/code/play/blog/node_modules/wordpress-export-to-markdown/index.js:65:14)
    at xml2js.parseString (/home/ed/code/play/blog/node_modules/wordpress-export-to-markdown/index.js:58:4)
    at Parser.<anonymous> (/home/ed/code/play/blog/node_modules/xml2js/lib/parser.js:303:18)
    at emitOne (events.js:116:13)
    at Parser.emit (events.js:211:7)
    at SAXParser.onclosetag (/home/ed/code/play/blog/node_modules/xml2js/lib/parser.js:261:26)

```

So, I've added an undefined check to the getPostCoverImageId function, and that fixed my issue. The export worked ok after that.

Let me know if you need me to add anything else to this PR.

Ed