### PR TITLE
import tags and categories into frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,10 @@ Whether or not to download and save images attached to posts. Generally speaking
 - Default: `false`
 
 Whether or not to also include images scraped from &lt;img&gt; tags in post body content. These images are downloaded and saved along with other images as dictated by `--saveimages`. The &lt;img&gt; tags are updated to point to where the images are saved.
+
+### --categoriestotags
+
+- Type: Boolean
+- Default: `false`
+
+Whether or not to treat category names as tags and lump both together in the frontmatter as `tags`.

--- a/index.js
+++ b/index.js
@@ -55,7 +55,7 @@ function parseFileContent(content) {
 	xml2js.parseString(content, processors, (err, data) => {
 		if (err) {
 			console.log('Unable to parse file content.');
-			console.log(err);        
+			console.log(err);
 		} else {
 			processData(data);
 		}
@@ -114,7 +114,7 @@ function addContentImages(data, images) {
 				console.log('Scraped ' + url + '.');
 			}
 		}
-	});	
+	});
 }
 
 function collectPosts(data) {
@@ -163,13 +163,13 @@ function initTurndownService() {
 			// but this series of checks should find the commonalities
 			return (
 				['P', 'DIV'].includes(node.nodeName) &&
-				node.attributes['data-slug-hash'] && 
+				node.attributes['data-slug-hash'] &&
 				node.getAttribute('class') === 'codepen'
 			);
 		},
 		replacement: (content, node) => '\n\n' + node.outerHTML
 	});
-		
+
 	// preserve embedded scripts (for tweets, codepens, gists, etc.)
 	turndownService.addRule('script', {
 		filter: 'script',
@@ -323,7 +323,7 @@ function writeMarkdownFile(post, postDir) {
 			return accumulator + pair[0] + ': ' + pair[1] + '\n'
 		}, '');
 	const data = '---\n' + frontmatter + '---\n\n' + post.content + '\n';
-	
+
 	const postPath = path.join(postDir, getPostFilename(post));
 	fs.writeFile(postPath, data, (err) => {
 		if (err) {

--- a/index.js
+++ b/index.js
@@ -223,13 +223,18 @@ function getPostDate(post) {
 }
 
 function getTags(post) {
-	let tags = post.category.filter(cat => ['post_tag'].includes(cat.$.domain)).map(tag => tag.$.nicename);
+	if (typeof post.category === 'undefined' || post.category === null) {
+		return '[]';
+	}
 	return '[' + tags.join(", ") + ']';
 }
 
 function getCategory(post) {
+	if (typeof post.category === 'undefined' || post.category === null) {
+		return '[]';
+	}
 	let categories = post.category.filter(cat => ['category'].includes(cat.$.domain)).map(tag => tag.$.nicename);
-	return '[' + tagStr + ']';
+	return '[' + categories.join(", ") + ']';
 }
 
 function getPostContent(post, turndownService) {

--- a/index.js
+++ b/index.js
@@ -128,11 +128,17 @@ function collectPosts(data) {
 				coverImageId: getPostCoverImageId(post)
 			},
 			frontmatter: {
-				title: getPostTitle(post),
-				date: getPostDate(post)
+				title: enquote(getPostTitle(post)),
+				date: enquote(getPostDate(post)),
+				tags: getTags(post),
+				category: getCategory(post)
 			},
 			content: getPostContent(post, turndownService)
 		}));
+}
+
+function enquote(str) {
+	return '"' + str + '"';
 }
 
 function initTurndownService() {
@@ -216,6 +222,16 @@ function getPostDate(post) {
 	return luxon.DateTime.fromRFC2822(post.pubDate[0], { zone: 'utc' }).toISODate();
 }
 
+function getTags(post) {
+	let tags = post.category.filter(cat => ['post_tag'].includes(cat.$.domain)).map(tag => tag.$.nicename);
+	return '[' + tags.join(", ") + ']';
+}
+
+function getCategory(post) {
+	let categories = post.category.filter(cat => ['category'].includes(cat.$.domain)).map(tag => tag.$.nicename);
+	return '[' + tagStr + ']';
+}
+
 function getPostContent(post, turndownService) {
 	let content = post.encoded[0].trim();
 
@@ -290,7 +306,7 @@ function writeFiles(posts) {
 function writeMarkdownFile(post, postDir) {
 	const frontmatter = Object.entries(post.frontmatter)
 		.reduce((accumulator, pair) => {
-			return accumulator + pair[0] + ': "' + pair[1] + '"\n'
+			return accumulator + pair[0] + ': ' + pair[1] + '\n'
 		}, '');
 	const data = '---\n' + frontmatter + '---\n\n' + post.content + '\n';
 	

--- a/index.js
+++ b/index.js
@@ -21,7 +21,8 @@ function init() {
 			'postfolders',
 			'prefixdate',
 			'saveimages',
-			'addcontentimages'
+			'addcontentimages',
+			'categoriestotags'
 		],
 		default: {
 			input: 'export.xml',
@@ -31,7 +32,8 @@ function init() {
 			postfolders: true,
 			prefixdate: false,
 			saveimages: true,
-			addcontentimages: false
+			addcontentimages: false,
+			categoriestotags: false
 		}
 	});
 
@@ -226,10 +228,17 @@ function getTags(post) {
 	if (typeof post.category === 'undefined' || post.category === null) {
 		return '[]';
 	}
+	let tagDomains = argv.categoriestotags
+		? ['post_tag']
+		: ['post_tag', 'category'];
+	let tags = post.category.filter(cat => tagDomains.includes(cat.$.domain)).map(tag => tag.$.nicename);
 	return '[' + tags.join(", ") + ']';
 }
 
 function getCategory(post) {
+	if (argv.categoriestotags) {
+		return '[]';
+	}
 	if (typeof post.category === 'undefined' || post.category === null) {
 		return '[]';
 	}


### PR DESCRIPTION
First off, I really dig the style here so far: lots of data transformations. Nice!

This PR closes #3:

- Imports categories as YAML String array looking for `<category domain="category" nicename="foo">...</category>`
- Imports tags as YAML String array looking for `<category domain="post_tag" nicename="bar">...</category>`
- Adds a `--categoriestotags` flag to import `<category domain="category" nicename="foobar"><![CDATA[Foobar]]></category>` as tag "foobar" instead of as a category

When no tags or categories are found, the respective key is not added to the YAML frontmatter. Then the frontmatter looks exactly like it did before my patch.
