### PR TITLE
Encode and decode URL

### DIFF
--- a/index.js
+++ b/index.js
@@ -278,7 +278,8 @@ function writeFiles(posts) {
 		writeMarkdownFile(post, postDir);
 
 		if (argv.saveimages && post.meta.imageUrls) {
-			post.meta.imageUrls.forEach(imageUrl => {
+			post.meta.imageUrls.forEach(imgUrl => {
+ 				const imageUrl = encodeURI(imgUrl);
 				const imageDir = path.join(postDir, 'images');
 				createDir(imageDir);
 				writeImageFile(imageUrl, imageDir, delay);
@@ -331,7 +332,7 @@ function writeImageFile(imageUrl, imageDir, delay) {
 }
 
 function getFilenameFromUrl(url) {
-	return url.split('/').slice(-1)[0];
+	return decodeURI(url.split('/').slice(-1)[0]);
 }
 
 function createDir(dir) {
@@ -353,7 +354,7 @@ function getPostDir(post) {
 	}
 
 	if (argv.postfolders) {
-		let folder = post.meta.slug;
+		let folder = decodeURI(post.meta.slug);
 		if (argv.prefixdate) {
 			folder = dt.toFormat('yyyy-LL-dd') + '-' + folder;
 		}


### PR DESCRIPTION
My blog has some images whose url contains Chinese, fetching these images will fail, error msg as follow. So it might be better to encode the requesting url, and the folder name and image name should be decoded because they are based on the encoded urls.
```
Unable to download image.
TypeError [ERR_UNESCAPED_CHARACTERS]: Request path contains unescaped characters
    at new ClientRequest (_http_client.js:140:13)
    at Object.request (http.js:44:10)
    at Request.start (/Users/ming/Desktop/wordpress-export-to-markdown/node_modules/request/request.js:751:32)
    at Request.end (/Users/ming/Desktop/wordpress-export-to-markdown/node_modules/request/request.js:1511:10)
    at end (/Users/ming/Desktop/wordpress-export-to-markdown/node_modules/request/request.js:564:14)
    at Immediate._onImmediate (/Users/ming/Desktop/wordpress-export-to-markdown/node_modules/request/request.js:578:7)
    at processImmediate (internal/timers.js:439:21)
```
Folder name before decode:
`%e4%b8%ba%e4%bb%80%e4%b9%88-pocket-%e5%ae%8c%e8%83%9c-instapaper`
Folder name after decode:
`为什么-pocket-完胜-instapaper`