### PR TITLE
Replace quotes in title with escaped quotes

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,7 +210,7 @@ function getPostSlug(post) {
 }
 
 function getPostTitle(post) {
-	return post.title[0].trim();
+	return post.title[0].trim().replace(/"/g, '\\"');
 }
 
 function getPostDate(post) {


### PR DESCRIPTION
Great tool you've built here, it saved me lots of time migrating my WordPress site to 11ty. Many thanks! 🙏

I came across an issue where if I had quotes in my title, it would output something like:

```
title: "Day 23:  "Nobody can hurt me without my permission." -Gandhi."
date: "2013-11-01"
```
This was causing 11ty to not be happy so this PR adds a simple `.replace` to the getPostTitle function to escape quotes, resulting in

```
title: "Day 23:  \"Nobody can hurt me without my permission.\" -Gandhi."
date: "2013-11-01"
```

After I made this change I had no issue importing my posts into 11ty.