### PR TITLE
Add npm command so it be run via npx

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ You'll need:
 - [Node.js](https://nodejs.org/) v10.12 or later
 - Your [WordPress export file](https://codex.wordpress.org/Tools_Export_Screen)
 
-There are a few ways you can run the package:
+There are a few ways you can use this package:
 
-1. use npx example: `npx wordpress-export-to-markdown --input=wordpress_export_file.xml`
-2. install it via npm: `npm i wordpress-export-to-markdown` then run `wordpress-export-to-markdown --input=wordpress_export_file.xml`
-3. Clone this repository, open your terminal then run `npm install` and then `node index.js`.
+1. To run via `npx`, run `npx wordpress-export-to-markdown`
+2. To add to an existing repo, run `npm i wordpress-export-to-markdown` and then `wordpress-export-to-markdown`
+3. Clone this repo, open your terminal to this package's directory, then run `npm install` and then `node index.js`
 
 This will create an `/output` folder filled with your posts and images.
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,11 @@ You'll need:
 - [Node.js](https://nodejs.org/) v10.12 or later
 - Your [WordPress export file](https://codex.wordpress.org/Tools_Export_Screen)
 
-Open your terminal to this package's directory. Run `npm install` and then `node index.js`.
+There are a few ways you can run the package:
+
+1. use npx example: `npx w2m --input=wordpress_export_file.xml`
+2. install it via npm: `npm i wordpress-export-to-markdown` then run `w2m --input=wordpress_export_file.xml`
+3. Clone this repository, open your terminal then run `npm install` and then `node index.js`.
 
 This will create an `/output` folder filled with your posts and images.
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ You'll need:
 
 There are a few ways you can run the package:
 
-1. use npx example: `npx w2m --input=wordpress_export_file.xml`
-2. install it via npm: `npm i wordpress-export-to-markdown` then run `w2m --input=wordpress_export_file.xml`
+1. use npx example: `npx wordpress-export-to-markdown --input=wordpress_export_file.xml`
+2. install it via npm: `npm i wordpress-export-to-markdown` then run `wordpress-export-to-markdown --input=wordpress_export_file.xml`
 3. Clone this repository, open your terminal then run `npm install` and then `node index.js`.
 
 This will create an `/output` folder filled with your posts and images.

--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 const fs = require('fs');
 const luxon = require('luxon');
 const minimist = require('minimist');
@@ -49,11 +51,11 @@ function readFile(path) {
 }
 
 function parseFileContent(content) {
-	const processors = { tagNameProcessors: [ xml2js.processors.stripPrefix ] };
+	const processors = { tagNameProcessors: [xml2js.processors.stripPrefix] };
 	xml2js.parseString(content, processors, (err, data) => {
 		if (err) {
 			console.log('Unable to parse file content.');
-			console.log(err);        
+			console.log(err);
 		} else {
 			processData(data);
 		}
@@ -112,7 +114,7 @@ function addContentImages(data, images) {
 				console.log('Scraped ' + url + '.');
 			}
 		}
-	});	
+	});
 }
 
 function collectPosts(data) {
@@ -155,13 +157,13 @@ function initTurndownService() {
 			// but this series of checks should find the commonalities
 			return (
 				['P', 'DIV'].includes(node.nodeName) &&
-				node.attributes['data-slug-hash'] && 
+				node.attributes['data-slug-hash'] &&
 				node.getAttribute('class') === 'codepen'
 			);
 		},
 		replacement: (content, node) => '\n\n' + node.outerHTML
 	});
-		
+
 	// preserve embedded scripts (for tweets, codepens, gists, etc.)
 	turndownService.addRule('script', {
 		filter: 'script',
@@ -294,7 +296,7 @@ function writeMarkdownFile(post, postDir) {
 			return accumulator + pair[0] + ': "' + pair[1] + '"\n'
 		}, '');
 	const data = '---\n' + frontmatter + '---\n\n' + post.content + '\n';
-	
+
 	const postPath = path.join(postDir, getPostFilename(post));
 	fs.writeFile(postPath, data, (err) => {
 		if (err) {

--- a/package.json
+++ b/package.json
@@ -25,6 +25,6 @@
 		"xml2js": "^0.4.22"
 	},
 	"bin": {
-		"w2m": "./index.js"
+		"wordpress-export-to-markdown": "./index.js"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
 		"request": "^2.88.0",
 		"turndown": "^5.0.3",
 		"xml2js": "^0.4.22"
+	},
+	"bin": {
+		"w2m": "./index.js"
 	}
 }


### PR DESCRIPTION
npx is an NPM package runner, it allows you to run NPM command without having to download and install npm packages if you only want to use a certain command once.

One very common use of npx is: `npx create-react-app my-starter` which will generate a starter template for React. I taught it would be a good idea to have the same functionality for this library.

I have called the command: w2m, let me know if you want to change it, we can name it anything within reason.

Testing Instructions:
1. Clone the [fork](https://github.com/jaslloyd/wordpress-export-to-markdown)
2. Open a terminal and run npm link (this will allow us to run npm commands)
3. wordpress-export-to-markdown [arguments you normally pass to index.js]

p.s My editor changed some formatting stuff let me know if you want me to revert.
