### PR TITLE
Add User-Agent to image request to prevent 403 response status

### DIFF
--- a/src/writer.js
+++ b/src/writer.js
@@ -97,7 +97,10 @@ async function loadImageFilePromise(imageUrl) {
 	try {
 		buffer = await requestPromiseNative.get({
 			url: imageUrl,
-			encoding: null // preserves binary encoding
+			encoding: null, // preserves binary encoding
+			headers: {
+				'User-Agent' : 'wordpress-export-to-markdown'
+			}
 		});
 	} catch (ex) {
 		if (ex.name === 'StatusCodeError') {


### PR DESCRIPTION
The Wordpress site I tried to import returned a 403 if the request had no User-Agent