### PR TITLE
Add time to post date, add categories & tags

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -94,10 +94,12 @@ function getTags(post) {
 }
 
 function processCategoryTags(post, domain) {
+	if (!post.category) {
+		return [];
+	}
 	return post.category
 		.filter(c => c["$"].domain === domain)
-		.map(({ $: c }) => c.nicename)
-		.join(", ");
+		.map(({ $: c }) => c.nicename);
 }
 
 function collectAttachedImages(data) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -48,7 +48,9 @@ function collectPosts(data, config) {
 			},
 			frontmatter: {
 				title: getPostTitle(post),
-				date: getPostDate(post)
+				date: getPostDate(post),
+				categories: getCategories(post),
+				tags: getTags(post),
 			},
 			content: translator.getPostContent(post, turndownService, config)
 		}));
@@ -80,7 +82,22 @@ function getPostTitle(post) {
 }
 
 function getPostDate(post) {
-	return luxon.DateTime.fromRFC2822(post.pubDate[0], { zone: 'utc' }).toISODate();
+	return luxon.DateTime.fromRFC2822(post.pubDate[0], { zone: 'utc' }).toISO();
+}
+
+function getCategories(post) {
+	return processCategoryTags(post, "category");
+}
+
+function getTags(post) {
+	return processCategoryTags(post, "post_tag");
+}
+
+function processCategoryTags(post, domain) {
+	return post.category
+		.filter(c => c["$"].domain === domain)
+		.map(({ $: c }) => c.nicename)
+		.join(", ");
 }
 
 function collectAttachedImages(data) {

--- a/src/writer.js
+++ b/src/writer.js
@@ -58,8 +58,10 @@ async function loadMarkdownFilePromise(post) {
 	let output = '---\n';
 	Object.entries(post.frontmatter).forEach(pair => {
 		const key = pair[0];
-		const value = (pair[1] || '').replace(/"/g, '\\"');
-		output += key + ': "' + value + '"\n';
+		const value = Array.isArray(pair[1])
+			? (pair[1].length === 0 ? "" : "\n  - \"" + pair[1].join("\"\n  - \"") + "\"")
+			: '"' + (pair[1] || '').replace(/"/g, '\\"') +'"';
+		output += key + ': ' + value + '\n';
 	});
 	output += '---\n\n' + post.content + '\n';
 	return output;


### PR DESCRIPTION
This change offers three improvements:
- Addition of time in the frontmatter 'date' field (today it is only YYYY-mm-dd)
- Addition of categories (as an array) to frontmatter
- Addition of tags (as an array) to frontmatter

Example:
```markdown
---
title: "Episode 3 - Web Browsers, Word Processors, and Budgeting"
date: "2018-08-02T03:24:08.000Z"
categories: 
  - "finance"
  - "general"
tags: 
  - "budgeting"
  - "finance"
  - "firefox"
  - "netscape"
  - "office"
  - "web-browsers"
---
```
