### PR TITLE
Adds support for slug from wordpress link in frontmatter section

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -58,31 +58,31 @@ function collectPosts(data, postTypes, config) {
 			.filter(post => post.status[0] !== 'trash' && post.status[0] !== 'draft')
 			.map(post => { 
 				const postMapped = {};
-        // meta data isn't written to file, but is used to help with other things
-        postMapped.meta = {
-          id: getPostId(post),
-          slug: getPostSlug(post),
-          coverImageId: getPostCoverImageId(post),
-          type: postType,
-          imageUrls: [],
-        };
-        postMapped.frontmatter = {
-          title: getPostTitle(post),
-          date: getPostDate(post),
-          categories: getCategories(post),
-          tags: getTags(post),
-        };
-        if (config.slug) {
-          postMapped.frontmatter.slug = getFrontmatterSlug(post);
-        }
-        
-        postMapped.content = translator.getPostContent(
-          post,
-          turndownService,
-          config
-        );
+				// meta data isn't written to file, but is used to help with other things
+				postMapped.meta = {
+					id: getPostId(post),
+					slug: getPostSlug(post),
+					coverImageId: getPostCoverImageId(post),
+					type: postType,
+					imageUrls: [],
+				};
+				postMapped.frontmatter = {
+					title: getPostTitle(post),
+					date: getPostDate(post),
+					categories: getCategories(post),
+					tags: getTags(post),
+				};
+				if (config.slug) {
+					postMapped.frontmatter.slug = getFrontmatterSlug(post);
+				}
+				
+				postMapped.content = translator.getPostContent(
+					post,
+					turndownService,
+					config
+				);
 
-        return postMapped;
+				return postMapped;
 			});
 
 		if (postTypes.length > 1) {
@@ -107,8 +107,8 @@ function getPostSlug(post) {
 }
 
 function getFrontmatterSlug(post) {
-  const url = new URL(post.link[0]);
-  return decodeURIComponent(url.pathname.replace(/\//g, ''));
+	const url = new URL(post.link[0]);
+	return decodeURIComponent(url.pathname.replace(/\//g, ''));
 }
 
 function getPostCoverImageId(post) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -56,23 +56,34 @@ function collectPosts(data, postTypes, config) {
 	postTypes.forEach(postType => {
 		const postsForType = getItemsOfType(data, postType)
 			.filter(post => post.status[0] !== 'trash' && post.status[0] !== 'draft')
-			.map(post => ({
-				// meta data isn't written to file, but is used to help with other things
-				meta: {
-					id: getPostId(post),
-					slug: getPostSlug(post),
-					coverImageId: getPostCoverImageId(post),
-					type: postType,
-					imageUrls: []
-				},
-				frontmatter: {
-					title: getPostTitle(post),
-					date: getPostDate(post),
-					categories: getCategories(post),
-					tags: getTags(post)
-				},
-				content: translator.getPostContent(post, turndownService, config)
-			}));
+			.map(post => { 
+				const postMapped = {};
+        // meta data isn't written to file, but is used to help with other things
+        postMapped.meta = {
+          id: getPostId(post),
+          slug: getPostSlug(post),
+          coverImageId: getPostCoverImageId(post),
+          type: postType,
+          imageUrls: [],
+        };
+        postMapped.frontmatter = {
+          title: getPostTitle(post),
+          date: getPostDate(post),
+          categories: getCategories(post),
+          tags: getTags(post),
+        };
+        if (config.slug) {
+          postMapped.frontmatter.slug = getFrontmatterSlug(post);
+        }
+        
+        postMapped.content = translator.getPostContent(
+          post,
+          turndownService,
+          config
+        );
+
+        return postMapped;
+			});
 
 		if (postTypes.length > 1) {
 			console.log(`${postsForType.length} "${postType}" posts found.`);
@@ -93,6 +104,11 @@ function getPostId(post) {
 
 function getPostSlug(post) {
 	return decodeURIComponent(post.post_name[0]);
+}
+
+function getFrontmatterSlug(post) {
+  const url = new URL(post.link[0]);
+  return decodeURIComponent(url.pathname.replace(/\//g, ''));
 }
 
 function getPostCoverImageId(post) {

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -74,7 +74,13 @@ const options = [
 		type: 'boolean',
 		description: 'Include custom post types and pages',
 		default: false
-	}
+	},
+  {
+    name: 'slug',
+    type: 'boolean',
+    description: 'Set slug in front-matter based on wordpress link',
+    default: false,
+  },
 ];
 
 async function getConfig(argv) {

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -75,12 +75,12 @@ const options = [
 		description: 'Include custom post types and pages',
 		default: false
 	},
-  {
-    name: 'slug',
-    type: 'boolean',
-    description: 'Set slug in front-matter based on wordpress link',
-    default: false,
-  },
+	{
+		name: 'slug',
+		type: 'boolean',
+		description: 'Set slug in front-matter based on wordpress link',
+		default: false,
+	},
 ];
 
 async function getConfig(argv) {


### PR DESCRIPTION
Hi!

While moving my blog from WordPress to Hugo, I ran to issue with slug. This tool doesn't export slug from WordPress link section, so if you have a different slug than your post title, some URLs could not work after migration.

In this PR, I've added support for it:
– slug is pulled out from link attribute in post object
– it's optional (default it's disabled)
– to turn it on, just add --slug=true argument in CLI, or proper answer to wizard question ;)

I needed to change a bit your map function, hope it's still clear to read.

I think it can be quite helpful feature for other developers.

Thank you for this tool, it's awesome and speeds up migration so much!