### PR TITLE
Add support for Enlighter code blocks

### DIFF
--- a/src/translator.js
+++ b/src/translator.js
@@ -46,7 +46,7 @@ function initTurndownService() {
 
 	// preserve enlighter code blocks
 	turndownService.addRule('enlighter', {
-		filter: node => node.nodeName === 'PRE' && node.getAttribute('class') === 'EnlighterJSRAW',
+		filter: (node) => node.nodeName === 'PRE' && node.classList.contains('EnlighterJSRAW'),
 		replacement: (content, node) => {
 			const language = node.getAttribute('data-enlighter-language') ?? '';
 			return '\n' + '```' + language + '\n' + content + '\n' + '```' + '\n';

--- a/src/translator.js
+++ b/src/translator.js
@@ -44,6 +44,15 @@ function initTurndownService() {
 		}
 	});
 
+	// preserve enlighter code blocks
+	turndownService.addRule('enlighter', {
+		filter: node => node.nodeName === 'PRE' && node.getAttribute('class') === 'EnlighterJSRAW',
+		replacement: (content, node) => {
+			const language = node.getAttribute('data-enlighter-language') ?? '';
+			return '\n' + '```' + language + '\n' + content + '\n' + '```' + '\n';
+		}
+	});
+
 	// preserve iframes (common for embedded audio/video)
 	turndownService.addRule('iframe', {
 		filter: 'iframe',


### PR DESCRIPTION
To add support for [Enlighter](https://wordpress.org/plugins/enlighter/) code blocks, I have added a turndown rule.

An Enlighter code block typically gets exported by Wordpress to the following format:

```xml
<!-- wp:enlighter/codeblock {"language":"typescript"} -->
<pre class="EnlighterJSRAW" data-enlighter-language="typescript" data-enlighter-theme="" data-enlighter-highlight="" data-enlighter-linenumbers="" data-enlighter-lineoffset="" data-enlighter-title="" data-enlighter-group="">// foo equals "bar"
const foo "bar";</pre>
<!-- /wp:enlighter/codeblock -->
```

The selector therefore is a combination of the node name `'PRE'` and the class `'EnlighterJSRaw'`. The language can be found in the `data-enlighter-language` attribute. Lastly, instead of using the `node.innerHTML` property, I use the `content` property. If I use `node.innerHTML`, the `<` are escaped to `&lt;` and so on...

Output then becomes:

````
```typescript
// foo equals "bar"
const foo = "bar";
```
````