### PR TITLE
Fixes #66: Invalid date on custom formatted dates

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -68,6 +68,7 @@ function collectPosts(data, postTypes, config) {
 				frontmatter: {
 					title: getPostTitle(post),
 					date: getPostDate(post),
+					date_unformatted: getPostDate(post, true),
 					categories: getCategories(post),
 					tags: getTags(post)
 				},
@@ -109,10 +110,10 @@ function getPostTitle(post) {
 	return post.title[0];
 }
 
-function getPostDate(post) {
+function getPostDate(post, ignoreFormatting = false) {
 	const dateTime = luxon.DateTime.fromRFC2822(post.pubDate[0], { zone: 'utc' });
 
-	if (settings.custom_date_formatting) {
+	if (settings.custom_date_formatting && !ignoreFormatting) {
 		return dateTime.toFormat(settings.custom_date_formatting);
 	} else if (settings.include_time_with_date) {
 		return dateTime.toISO();

--- a/src/writer.js
+++ b/src/writer.js
@@ -26,7 +26,7 @@ async function processPayloadsPromise(payloads, loadFunc) {
 			}
 		}, payload.delay);
 	}));
-	
+
 	const results = await Promise.allSettled(promises);
 	const failedCount = results.filter(result => result.status === 'rejected').length;
 	if (failedCount === 0) {
@@ -157,7 +157,7 @@ async function loadImageFilePromise(imageUrl) {
 }
 
 function getPostPath(post, config) {
-	const dt = luxon.DateTime.fromISO(post.frontmatter.date);
+	const dt = luxon.DateTime.fromISO(post.frontmatter.date_unformatted);
 
 	// start with base output dir
 	const pathSegments = [config.output];


### PR DESCRIPTION
Fixes #66: Invalid date on custom formatted dates

Using a custom date format (example: `exports.custom_date_formatting = 'LLL d yyyy'`) along with `prefix-dates` causes filenames to be prefixed with `Invalid date`.

I see there is another PR for this but the code is not merged.