### PR TITLE
Option to add WordPress Metadata to front matter

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const writer = require('./src/writer');
 	const config = await wizard.getConfig(process.argv);
 
 	// parse data from XML and do Markdown translations
-	const posts = await parser.parseFilePromise(config)
+	const posts = await parser.parseFilePromise(config);
 
 	// write files, downloading images as needed
 	await writer.writeFilesPromise(posts, config);

--- a/src/parser.js
+++ b/src/parser.js
@@ -27,6 +27,12 @@ async function parseFilePromise(config) {
 
 	mergeImagesIntoPosts(images, posts);
 
+	if(config.includeWpFrontmatter){
+		console.log('adding Wordpress metadata to frontmatter');
+		addWPFrontMatter(posts);
+
+	}
+
 	return posts;
 }
 
@@ -199,6 +205,14 @@ function mergeImagesIntoPosts(images, posts) {
 				post.meta.imageUrls.push(image.url);
 			}
 		});
+	});
+}
+
+function addWPFrontMatter(posts) {
+	posts.forEach(post => {
+		post.frontmatter.wp_id = post.meta.id;
+		post.frontmatter.wp_slug = post.meta.slug;
+		post.frontmatter.wp_type = post.meta.type;
 	});
 }
 

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -74,6 +74,12 @@ const options = [
 		type: 'boolean',
 		description: 'Include custom post types and pages',
 		default: false
+	},
+	{
+		name: 'include-wp-frontmatter',
+		type: 'boolean',
+		description: 'Include Wordpress metadata in frontmatter',
+		default: false
 	}
 ];
 


### PR DESCRIPTION
Setting the `--include-wp-frontmatter` option to `true` will add the following keys to the front matter on each rendered markdown file:

* `wp_id`: the post's ID in WordPress
* `wp_slug`: the post's slug in WordPress
* `wp_type`: the post's WordPress type

I tried to copy all the relevant naming conventions and coding styles so this code fits in to the project's structure. Hope I didn't make any silly mistakes 🤞