### PR TITLE
Add option to write a JSON file mapping Wordpress IDs to relative Markdown file paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ const writer = require('./src/writer');
 	const config = await wizard.getConfig(process.argv);
 
 	// parse data from XML and do Markdown translations
-	const posts = await parser.parseFilePromise(config)
+	const posts = await parser.parseFilePromise(config);
 
 	// write files, downloading images as needed
 	await writer.writeFilesPromise(posts, config);

--- a/src/parser.js
+++ b/src/parser.js
@@ -27,6 +27,12 @@ async function parseFilePromise(config) {
 
 	mergeImagesIntoPosts(images, posts);
 
+	if(config.includeWpFrontmatter){
+		console.log('adding Wordpress metadata to frontmatter');
+		addWPFrontMatter(posts);
+
+	}
+
 	return posts;
 }
 
@@ -199,6 +205,14 @@ function mergeImagesIntoPosts(images, posts) {
 				post.meta.imageUrls.push(image.url);
 			}
 		});
+	});
+}
+
+function addWPFrontMatter(posts) {
+	posts.forEach(post => {
+		post.frontmatter.wp_id = post.meta.id;
+		post.frontmatter.wp_slug = post.meta.slug;
+		post.frontmatter.wp_type = post.meta.type;
 	});
 }
 

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -74,6 +74,12 @@ const options = [
 		type: 'boolean',
 		description: 'Include custom post types and pages',
 		default: false
+	},
+	{
+		name: 'include-wp-frontmatter',
+		type: 'boolean',
+		description: 'Include Wordpress metadata in frontmatter',
+		default: false
 	}
 ];
 

--- a/src/wizard.js
+++ b/src/wizard.js
@@ -80,6 +80,12 @@ const options = [
 		type: 'boolean',
 		description: 'Include Wordpress metadata in frontmatter',
 		default: false
+	},
+	{
+		name: 'write-wp-id-file-map',
+		type: 'boolean',
+		description: 'Write wp-id-file-map.json file mapping wordpress IDs to Markdown files',
+		default: false
 	}
 ];
 


### PR DESCRIPTION
Add option `--write-wp-id-file-map` to enable outputting of a JSON data structure mapping WordPress post IDs to relative Markdown file paths  to `wp-id-file-map.json`.

This may be a little too specific to my needs to get merged, but I need this file so I can auto-generate an NGINX config file to redirect old ?post=... URLs to the new static files, and others may need to do similarly create redirects from old Wordpress URLs to new static URLs.