### PR TITLE
Convert preformatted blocks

### DIFF
--- a/src/translator.js
+++ b/src/translator.js
@@ -53,6 +53,20 @@ function initTurndownService() {
 		}
 	});
 
+	turndownService.addRule("pre", {
+		filter: (node, options) => {
+			return (
+				options.codeBlockStyle === "fenced" &&
+				node.nodeName === "PRE" &&
+				node.firstChild
+			);
+		},
+		replacement: (content, node) => {
+			const code = node.textContent;
+			return "\n" + "```" + "\n" + code + "\n" + "```" + "\n";
+		},
+	});
+
 	return turndownService;
 }
 


### PR DESCRIPTION
My wordpress blog had a lot of `<pre>` sections. The conversion to markdown ignored those. This change did what I wanted, which was to turn all of these into markdown code blocks. In my case, there was no language set on any of my sections to carry over into markdown, so that isn't handled at all.

I'm not sure if this is helpful more broadly, but I figured I'd post it in case it helps someone else.