### PR TITLE
Fix pub date being incorrectly encoded as string in frontmatter

### DIFF
--- a/src/frontmatter/date.js
+++ b/src/frontmatter/date.js
@@ -5,13 +5,7 @@ const settings = require('../settings');
 // get post date, optionally formatted as specified in settings
 // this value is also used for year/month folders, date prefixes, etc. as needed
 module.exports = (post) => {
-	const dateTime = luxon.DateTime.fromRFC2822(post.data.pubDate[0], { zone: settings.custom_date_timezone });
-
-	if (settings.custom_date_formatting) {
-		return dateTime.toFormat(settings.custom_date_formatting);
-	} else if (settings.include_time_with_date) {
-		return dateTime.toISO();
-	} else {
-		return dateTime.toISODate();
-	}
+	return luxon.DateTime.fromRFC2822(post.data.pubDate[0], {
+		zone: settings.custom_date_timezone,
+	});
 };

--- a/src/writer.js
+++ b/src/writer.js
@@ -84,6 +84,8 @@ async function loadMarkdownFilePromise(post) {
 				// array of one or more strings
 				outputValue = value.reduce((list, item) => `${list}\n  - "${item}"`, '');
 			}
+		} else if (value instanceof luxon.DateTime) {
+			outputValue = encodeDate(value);
 		} else {
 			// single string value
 			const escapedValue = (value || '').replace(/"/g, '\\"');
@@ -99,6 +101,16 @@ async function loadMarkdownFilePromise(post) {
 
 	output += `---\n\n${post.content}\n`;
 	return output;
+}
+
+function encodeDate(dateTime) {
+	if (settings.custom_date_formatting) {
+		return dateTime.toFormat(settings.custom_date_formatting);
+	} else if (settings.include_time_with_date) {
+		return dateTime.toISO();
+	} else {
+		return dateTime.toISODate();
+	}
 }
 
 async function writeImageFilesPromise(posts, config) {


### PR DESCRIPTION
This PR changes how datetimes are encoded in frontmatter. In current version, they're encoded as strings (enclosed in quotes). After this change encodes datetimes to YAML timestamps (without quotes).

ie. current behavior:
```md
---
date: "2022-10-28"
---
```

new result:

```md
---
date: 2022-10-28
---
```

This is done by moving pub date encoding logic from parser to writer. Parser now keeps datetime as `luxon.DateTime` type and writer takes responsibility for converting this to string, deciding upon frontmatter value type and settings.