### PR TITLE
store date as meta

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -69,6 +69,7 @@ function collectPosts(channelData, postTypes, config) {
 				meta: {
 					id: getPostId(postData),
 					slug: getPostSlug(postData),
+					date: undefined, // possibly set later in populateFrontmatter()
 					coverImageId: getPostCoverImageId(postData),
 					coverImage: undefined, // possibly set later in mergeImagesIntoPosts()
 					type: postType,
@@ -186,6 +187,7 @@ function populateFrontmatter(posts) {
 			frontmatter[alias || key] = frontmatterGetter(post);
 		});
 		post.frontmatter = frontmatter;
+		post.meta.date = frontmatterGetters['date'](post);
 	});
 }
 

--- a/src/writer.js
+++ b/src/writer.js
@@ -175,9 +175,9 @@ async function loadImageFilePromise(imageUrl) {
 function getPostPath(post, config) {
 	let dt;
 	if (settings.custom_date_formatting) {
-		dt = luxon.DateTime.fromFormat(post.frontmatter.date, settings.custom_date_formatting);
+		dt = luxon.DateTime.fromFormat(post.meta.date, settings.custom_date_formatting);
 	} else {
-		dt = luxon.DateTime.fromISO(post.frontmatter.date);
+		dt = luxon.DateTime.fromISO(post.meta.date);
 	}
 
 	// start with base output dir

--- a/src/writer.js
+++ b/src/writer.js
@@ -175,9 +175,9 @@ async function loadImageFilePromise(imageUrl) {
 function getPostPath(post, config) {
 	let dt;
 	if (settings.custom_date_formatting) {
-		dt = luxon.DateTime.fromFormat(post.meta.date, settings.custom_date_formatting);
+		dt = luxon.DateTime.fromFormat(post.meta.date, settings.custom_date_formatting, { zone: settings.custom_date_timezone });
 	} else {
-		dt = luxon.DateTime.fromISO(post.meta.date);
+		dt = luxon.DateTime.fromISO(post.meta.date, { zone: settings.custom_date_timezone });
 	}
 
 	// start with base output dir


### PR DESCRIPTION
Fixed a bug in `settings.js` that if you set an alias like `date:pubDate` for a `date` front matter, `writer.js` cannot find `post.frontmatter.date` and cannot determine the file name, so `date` is kept and referenced in `meta`.