### PR TITLE
Convert `[code]` to fenced code blocs

### DIFF
--- a/src/translator.js
+++ b/src/translator.js
@@ -116,6 +116,13 @@ function getPostContent(postData, turndownService, config) {
 	// <pre> block, save it to a data attribute so the "pre" rule can use it
 	content = content.replace(/(<!-- wp:.+? \{"language":"(.+?)"\} -->\r?\n<pre )/g, '$1data-wetm-language="$2" ');
 
+	// convert [code] blocks with optional language to <code>
+	const codeRegex = /\[code(\s+language\s*=\s*"(?<lang>[^"]+)")?.*?\](?<src>.+?)\[\/code\]/gs;
+	content = content.replace(codeRegex, (match, _, lang, src) => {
+		const language = lang || 'none';
+		return `<div><pre><code class="language-${language}">${src.trim()}</code></pre></div>`;
+	});
+	
 	// use turndown to convert HTML to Markdown
 	content = turndownService.turndown(content);
 


### PR DESCRIPTION
Convert `[code language="some-language"] ... [/code]` to fenced code blocs.

### Example

```none
[code language="powershell" light="true"]
Write-Host "Hello world!"
[/code]
```

````
```powershell
Write-Host "Hello world!"
```
````