### PR TITLE
Fix an error that preventing to save image files whose filenames ...

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -122,7 +122,7 @@ function collectAttachedImages(allPostData) {
 		// filter to certain image file types
 		.filter((attachment) => {
 			const url = attachment.childValue('attachment_url');
-			return url && (/\.(gif|jpe?g|png|webp)$/i).test(url);
+			return url && (/\.(gif|jpe?g|png|webp)(\?|$)/i).test(url);
 		})
 		.map((attachment) => ({
 			id: attachment.childValue('post_id'),

--- a/src/shared.js
+++ b/src/shared.js
@@ -73,6 +73,14 @@ export function buildPostPath(post, overrideConfig) {
 
 export function getFilenameFromUrl(url) {
 	let filename = url.split('/').slice(-1)[0];
+	
+	// Remove query parameters and hash fragments from filename
+	filename = filename.split('?')[0].split('#')[0];
+	
+	// Replace any other invalid Windows filename characters
+	const invalidChars = /[<>:"\/\\|?*]/g;
+	filename = filename.replace(invalidChars, '_');
+	
 	try {
 		filename = decodeURIComponent(filename)
 	} catch (ex) {


### PR DESCRIPTION
… include query parameters (for example, "image-2.png?w=671" or "image-3.png?w=1024"). Windows doesn’t allow characters like “?” in filenames, so when the tool tries to open or save such a file, it fails with an ENOENT error.