### PR TITLE
remove-image-qs

### DIFF
--- a/src/translator.js
+++ b/src/translator.js
@@ -117,7 +117,7 @@ export function getPostContent(content) {
 	if (shared.config.saveImages === 'scraped' || shared.config.saveImages === 'all') {
 		// writeImageFile() will save all content images to a relative /images
 		// folder so update references in post content to match
-		content = content.replace(/(<img(?=\s)[^>]+?(?<=\s)src=")[^"]*?([^/"]+)("[^>]*>)/gi, '$1images/$2$3');
+		content = content.replace(/(<img(?=\s)[^>]+?(?<=\s)src=")[^"]*?([^/"]+?)(\?[^"]*)?("[^>]*>)/gi, '$1images/$2$4');
 	}
 
 	// preserve "more" separator, max one per post, optionally with custom label


### PR DESCRIPTION
Clean up unnecessary query strings on images in markdown that are downloaded.