### PR TITLE
feat: language-aware export to avoid WPML filename collisions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,14 +136,14 @@ Allowed values:
 ### Frontmatter fields?
 
 ```
---frontmatter-fields=title,date,categories,tags,coverImage,draft
+--frontmatter-fields=title,date,categories,tags,coverImage,lang,draft
 ```
 
 Comma separated list of the frontmatter fields to include in Markdown files. Order is preserved. If a post doesn't have a value for a field, it is left off.
 
 Allowed values:
 
-- A comma separated list with any of the following: `author`, `categories`, `coverImage`, `date`, `draft`, `excerpt`, `id`, `slug`, `tags`, `title`, `type`. You can rename a field by appending `:` and the alias to use. For example, `date:created` will rename `date` to `created`.
+- A comma separated list with any of the following: `author`, `categories`, `coverImage`, `date`, `draft`, `excerpt`, `id`, `lang`, `slug`, `tags`, `title`, `type`. You can rename a field by appending `:` and the alias to use. For example, `date:created` will rename `date` to `created`.
 
 ### Delay between image file requests?
 
@@ -231,6 +231,31 @@ Allowed values:
 
 - `true` - Use strict SSL. This is the safer option.
 - `false` - Don't use strict SSL. This will let you avoid the "self-signed certificate" error when working with a self-signed server. Just make sure you know what you're doing.
+
+### Append language code to slug?
+
+```
+--append-language-to-slug=true
+```
+
+Append a 2-letter language code (detected from the post URL) to each post slug to prevent filename or folder collisions on multilingual sites (e.g., WPML, Polylang). Regional variants like `en-us` are normalized to `en`. Applied to both file names and per-post folders.
+
+Allowed values:
+
+- `true` - Append the detected language code to the slug. Example: `2025-05-01-post` becomes `2025-05-01-post-en`.
+- `false` - Do not append a language code. Restores the previous behavior and may overwrite files when multiple languages share the same slug.
+
+### Default language?
+
+```
+--default-language=en
+```
+
+Fallback language code to use when the post URL does not contain a language prefix. The value is normalized to lowercase and used for the slug (if `--append-language-to-slug=true`) and the optional `lang` frontmatter field.
+
+Allowed values:
+
+- Any 2-letter ISO 639-1 code, for example: `en`, `de`, `it`, `fr`, `es`.
 
 ## Local Development
 

--- a/src/frontmatter.js
+++ b/src/frontmatter.js
@@ -61,3 +61,7 @@ export function type(post) {
 	// previously parsed but not decoded, can be "post", "page", or other custom types
 	return post.type;
 }
+
+export function lang(post) {
+  return post.lang;
+}

--- a/src/parser.js
+++ b/src/parser.js
@@ -85,6 +85,7 @@ function collectPosts(allPostData, postTypes) {
 }
 
 function buildPost(data) {
+	const lang = getLanguageCode(data);
 	return {
 		// full raw post data
 		data,
@@ -96,6 +97,7 @@ function buildPost(data) {
 		type: data.childValue('post_type'),
 		id: data.childValue('post_id'),
 		isDraft: data.childValue('status') === 'draft',
+		lang: lang,
 		slug: decodeURIComponent(data.childValue('post_name')),
 		date: getPostDate(data),
 		coverImageId: getPostMetaValue(data, '_thumbnail_id'),
@@ -104,6 +106,23 @@ function buildPost(data) {
 		coverImage: undefined,
 		imageUrls: []
 	};
+}
+
+function getLanguageCode(data) {
+  // aus https://domain.tld/en/blog/slug/ -> "en"
+  try {
+    const link = data.childValue('link');
+    if (link) {
+      const url = new URL(link);
+      const parts = url.pathname.split('/').filter((p) => p.length > 0);
+      const first = parts.length > 0 ? parts[0].toLowerCase() : undefined;
+      if (first && /^[a-z]{2}(-[a-z]{2})?$/.test(first)) {
+        return first.split('-')[0]; // normalisiert auf 2 Buchstaben
+      }
+    }
+  } catch (e) { /* ignore */ }
+  // Fallback, falls keine Sprachkennung in der URL steckt
+  return (shared.config.defaultLanguage || 'de').toLowerCase();
 }
 
 function getPostDate(data) {

--- a/src/questions.js
+++ b/src/questions.js
@@ -107,6 +107,18 @@ export function load() {
 			default: 'output'
 		},
 		{
+		    name: 'append-language-to-slug',
+		    type: 'boolean',
+		    description: 'Append language code to slug to prevent overwrites (WPML)',
+		    default: true
+		},
+		{
+		    name: 'default-language',
+		    type: 'string',
+		    description: 'Default language code when URL has no language prefix (e.g. de, en, it, fr, es)',
+		    default: 'de'
+		},
+		{
 			name: 'frontmatter-fields',
 			type: 'list',
 			description: 'Frontmatter fields',

--- a/src/shared.js
+++ b/src/shared.js
@@ -61,6 +61,11 @@ export function buildPostPath(post, overrideConfig) {
 		slug = post.date.toFormat('yyyy-LL-dd') + '-' + slug;
 	}
 
+	// Append language suffix to prevent WPML collisions
+	if ((pathConfig.appendLanguageToSlug ?? true) && post.lang) {
+		slug = slug + '-' + post.lang;
+	}
+
 	// use slug as folder or filename as specified
 	if (pathConfig.postFolders) {
 		pathSegments.push(slug, 'index.md');


### PR DESCRIPTION
- parser: detect language code from post URL and store as post.lang
  - supports 2-letter codes and regional variants (en-us -> en)
  - falls back to default language when no prefix is present

- shared: append language code to slug when enabled
  - controlled by new CLI flag --append-language-to-slug (default: true)
  - applied consistently to folder and filename paths
  - works with date-prefixed slugs and postFolders

- questions (CLI): add new flags
  - --append-language-to-slug=true
  - --default-language=de

- frontmatter: expose lang field
  - allows writing detected language to frontmatter when included in --frontmatter-fields

- docs(readme): document new flags and frontmatter usage
  - adds sections:
    - "Append language code to slug?"
    - "Default language?"
    - extends "Frontmatter fields?" with lang example

Notes:
- Normalizes regional variants like en-us to en to keep file names predictable.
- If you do not want language suffixes, run with --append-language-to-slug=false.