### PR TITLE
tweaks for postmeta & save posts as JSON

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,5 @@ tmp/
 
 #ignore specific filenames
 export.xml
+export*.xml
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -143,7 +143,13 @@ Comma separated list of the frontmatter fields to include in Markdown files. Ord
 
 Allowed values:
 
-- A comma separated list with any of the following: `author`, `categories`, `coverImage`, `date`, `draft`, `excerpt`, `id`, `slug`, `tags`, `title`, `type`. You can rename a field by appending `:` and the alias to use. For example, `date:created` will rename `date` to `created`.
+- A comma separated list with any of the following: `author`, `categories`, `coverImage`, `date`, `draft`, `excerpt`, `id`, `slug`, `tags`, `title`, `type`, `meta`. 
+    - You can rename a field by appending `:` and the alias to use. For example, `date:created` will rename `date` to `created`.
+    - `meta`: use *dot-notation* as following to access any available post-**meta** fields:
+        ```bash
+        npx wordpress-export-to-markdown  --frontmatter-fields "title,date,categories,tags,coverImage,draft,meta.YOUR_CUSTOM_FIELDNAME:maybeAliased"
+        ```
+        if the field is not available it is ignored.
 
 ### Delay between image file requests?
 

--- a/app.js
+++ b/app.js
@@ -25,6 +25,9 @@ import * as writer from './src/writer.js';
 	// parse data from XML and do Markdown translations
 	const posts = await parser.parseFilePromise()
 
+	console.log(posts);
+	
+
 	// write files and download images
 	await writer.writeFilesPromise(posts);
 
@@ -36,3 +39,4 @@ import * as writer from './src/writer.js';
 	console.log('\nSomething went wrong, execution halted early.');
 	console.error(ex);
 });
+

--- a/app.js
+++ b/app.js
@@ -25,9 +25,6 @@ import * as writer from './src/writer.js';
 	// parse data from XML and do Markdown translations
 	const posts = await parser.parseFilePromise()
 
-	console.log(posts);
-	
-
 	// write files and download images
 	await writer.writeFilesPromise(posts);
 

--- a/src/frontmatter.js
+++ b/src/frontmatter.js
@@ -61,3 +61,8 @@ export function type(post) {
 	// previously parsed but not decoded, can be "post", "page", or other custom types
 	return post.type;
 }
+
+
+export function meta(post) {
+	return post.meta;
+}

--- a/src/frontmatter.js
+++ b/src/frontmatter.js
@@ -62,7 +62,6 @@ export function type(post) {
 	return post.type;
 }
 
-
 export function meta(post) {
 	return post.meta;
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -86,25 +86,25 @@ function collectPosts(allPostData, postTypes) {
 
 function buildPost(data) {
 	return {
-        // full raw post data
-        data,
+		// full raw post data
+		data,
 
-        // body content converted to markdown
-        content: translator.getPostContent(data.childValue("encoded")),
+		// body content converted to markdown
+		content: translator.getPostContent(data.childValue("encoded")),
 
-        // particularly useful values for all sorts of things
-        type: data.childValue("post_type"),
-        id: data.childValue("post_id"),
-        isDraft: data.childValue("status") === "draft",
-        slug: decodeURIComponent(data.childValue("post_name")),
-        date: getPostDate(data),
-        meta: getPostMeta(data),
-        coverImageId: getPostMetaValue(data, "_thumbnail_id"),
+		// particularly useful values for all sorts of things
+		type: data.childValue("post_type"),
+		id: data.childValue("post_id"),
+		isDraft: data.childValue("status") === "draft",
+		slug: decodeURIComponent(data.childValue("post_name")),
+		date: getPostDate(data),
+		meta: getPostMeta(data),
+		coverImageId: getPostMetaValue(data, "_thumbnail_id"),
 
-        // these are possibly set later in mergeImagesIntoPosts()
-        coverImage: undefined,
-        imageUrls: [],
-    };
+		// these are possibly set later in mergeImagesIntoPosts()
+		coverImage: undefined,
+		imageUrls: [],
+	};
 }
 
 function getPostDate(data) {
@@ -115,16 +115,16 @@ function getPostDate(data) {
 function getPostMeta(data) {
 	const metas = data.children('postmeta');
 	let result = metas.reduce((acc, item) => {
-        const meta_key = item.childValue("meta_key");
-        const meta_value = item.childValue("meta_value");
-        // console.log("meta_key", meta_key);
-        // console.log("meta_value", meta_value);
-        // only add if meta_key is not starting with '_' as this seem to be internal field-names.
-        if (!meta_key.startsWith("_")) {
-            acc[meta_key] = meta_value;
-        }
-        return acc;
-    }, {});
+		const meta_key = item.childValue("meta_key");
+		const meta_value = item.childValue("meta_value");
+		// console.log("meta_key", meta_key);
+		// console.log("meta_value", meta_value);
+		// only add if meta_key is not starting with '_' as this seem to be internal field-names.
+		if (!meta_key.startsWith("_")) {
+			acc[meta_key] = meta_value;
+		}
+		return acc;
+	}, {});
 	return result;
 }
 
@@ -223,11 +223,16 @@ function populateFrontmatter(posts) {
 				const mainObj = frontmatterGetter(post);
 				frontmatterValue = mainObj[subKey];
 				if (!frontmatterValue) {
-                    throw `Could not find a frontmatter value for subKey "${subKey}".`;
-                }
-            } else {
+					// throw `Could not find a frontmatter value for subKey "${subKey}".`;
+					console.log(
+						`Could not find subKey "${subKey}" in postmeta. Ignoring.`
+					);
+				} else {
+					post.frontmatter[alias ?? key] = frontmatterValue;
+				}
+			} else {
+				post.frontmatter[alias ?? key] = frontmatterValue;
 			}
-			post.frontmatter[alias ?? key] = frontmatterValue;
 		});
 	});
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -86,29 +86,46 @@ function collectPosts(allPostData, postTypes) {
 
 function buildPost(data) {
 	return {
-		// full raw post data
-		data,
+        // full raw post data
+        data,
 
-		// body content converted to markdown
-		content: translator.getPostContent(data.childValue('encoded')),
+        // body content converted to markdown
+        content: translator.getPostContent(data.childValue("encoded")),
 
-		// particularly useful values for all sorts of things
-		type: data.childValue('post_type'),
-		id: data.childValue('post_id'),
-		isDraft: data.childValue('status') === 'draft',
-		slug: decodeURIComponent(data.childValue('post_name')),
-		date: getPostDate(data),
-		coverImageId: getPostMetaValue(data, '_thumbnail_id'),
+        // particularly useful values for all sorts of things
+        type: data.childValue("post_type"),
+        id: data.childValue("post_id"),
+        isDraft: data.childValue("status") === "draft",
+        slug: decodeURIComponent(data.childValue("post_name")),
+        date: getPostDate(data),
+        meta: getPostMeta(data),
+        coverImageId: getPostMetaValue(data, "_thumbnail_id"),
 
-		// these are possibly set later in mergeImagesIntoPosts()
-		coverImage: undefined,
-		imageUrls: []
-	};
+        // these are possibly set later in mergeImagesIntoPosts()
+        coverImage: undefined,
+        imageUrls: [],
+    };
 }
 
 function getPostDate(data) {
 	const date = luxon.DateTime.fromRFC2822(data.childValue('pubDate'), { zone: shared.config.timezone });
 	return date.isValid ? date : undefined;
+}
+
+function getPostMeta(data) {
+	const metas = data.children('postmeta');
+	let result = metas.reduce((acc, item) => {
+        const meta_key = item.childValue("meta_key");
+        const meta_value = item.childValue("meta_value");
+        // console.log("meta_key", meta_key);
+        // console.log("meta_value", meta_value);
+        // only add if meta_key is not starting with '_' as this seem to be internal field-names.
+        if (!meta_key.startsWith("_")) {
+            acc[meta_key] = meta_value;
+        }
+        return acc;
+    }, {});
+	return result;
 }
 
 function getPostMetaValue(data, key) {
@@ -196,13 +213,21 @@ function populateFrontmatter(posts) {
 		post.frontmatter = {};
 		shared.config.frontmatterFields.forEach((field) => {
 			const [key, alias] = field.split(':');
-
-			let frontmatterGetter = frontmatter[key];
+			const [frontmatterGetterKey, subKey] = key.split('.')
+			let frontmatterGetter = frontmatter[frontmatterGetterKey];
 			if (!frontmatterGetter) {
-				throw `Could not find a frontmatter getter named "${key}".`;
+				throw `Could not find a frontmatter getter named "${frontmatterGetterKey}".`;
 			}
-
-			post.frontmatter[alias ?? key] = frontmatterGetter(post);
+			let frontmatterValue = frontmatterGetter(post);
+			if (subKey) {
+				const mainObj = frontmatterGetter(post);
+				frontmatterValue = mainObj[subKey];
+				if (!frontmatterValue) {
+                    throw `Could not find a frontmatter value for subKey "${subKey}".`;
+                }
+            } else {
+			}
+			post.frontmatter[alias ?? key] = frontmatterValue;
 		});
 	});
 }

--- a/src/parser.js
+++ b/src/parser.js
@@ -90,16 +90,16 @@ function buildPost(data) {
 		data,
 
 		// body content converted to markdown
-		content: translator.getPostContent(data.childValue("encoded")),
+		content: translator.getPostContent(data.childValue('encoded')),
 
 		// particularly useful values for all sorts of things
-		type: data.childValue("post_type"),
-		id: data.childValue("post_id"),
-		isDraft: data.childValue("status") === "draft",
-		slug: decodeURIComponent(data.childValue("post_name")),
+		type: data.childValue('post_type'),
+		id: data.childValue('post_id'),
+		isDraft: data.childValue('status') === 'draft',
+		slug: decodeURIComponent(data.childValue('post_name')),
 		date: getPostDate(data),
 		meta: getPostMeta(data),
-		coverImageId: getPostMetaValue(data, "_thumbnail_id"),
+		coverImageId: getPostMetaValue(data, '_thumbnail_id'),
 
 		// these are possibly set later in mergeImagesIntoPosts()
 		coverImage: undefined,
@@ -113,7 +113,7 @@ function getPostDate(data) {
 }
 
 function getPostMeta(data) {
-	const metas = data.children('postmeta');
+	const metas = data.children("postmeta");
 	let result = metas.reduce((acc, item) => {
 		const meta_key = item.childValue("meta_key");
 		const meta_value = item.childValue("meta_value");

--- a/src/questions.js
+++ b/src/questions.js
@@ -4,155 +4,156 @@ export function load() {
 	// questions with a description are displayed in command line help
 	// questions with a prompt are included in the wizard (if not set on the command line)
 	return [
-		{
-			name: 'input',
-			type: 'file-path',
-			description: 'Path to WordPress export file',
-			default: 'export.xml',
-			prompt: inquirer.input
-		},
-		{
-			name: 'post-folders',
-			type: 'boolean',
-			description: 'Put each post into its own folder',
-			default: true,
-			choices: [
-				{
-					name: 'Yes',
-					value: true
-				},
-				{
-					name: 'No',
-					value: false
-				}
-			],
-			isPathQuestion: true,
-			prompt: inquirer.select
-		},
-		{
-			name: 'prefix-date',
-			type: 'boolean',
-			description: 'Add date prefix to posts',
-			default: false,
-			choices: [
-				{
-					name: 'Yes',
-					value: true
-				},
-				{
-					name: 'No',
-					value: false
-				}
-			],
-			isPathQuestion: true,
-			prompt: inquirer.select
-		},
-		{
-			name: 'date-folders',
-			type: 'choice',
-			description: 'Organize posts into date folders',
-			default: 'none',
-			choices: [
-				{
-					name: 'Year folders',
-					value: 'year'
-				},
-				{
-					name: 'Year and month folders',
-					value: 'year-month'
-				},
-				{
-					name: 'No',
-					value: 'none'
-				}
-			],
-			isPathQuestion: true,
-			prompt: inquirer.select
-		},
-		{
-			name: 'save-images',
-			type: 'choice',
-			description: 'Save images',
-			default: 'all',
-			choices: [
-				{
-					name: 'Images attached to posts',
-					value: 'attached'
-				},
-				{
-					name: 'Images scraped from post body content',
-					value: 'scraped'
-				},
-				{
-					name: 'All Images',
-					value: 'all'
-				},
-				{
-					name: 'No',
-					value: 'none'
-				}
-			],
-			prompt: inquirer.select
-		},
-		{
-			name: 'wizard',
-			type: 'boolean',
-			description: 'Use wizard',
-			default: true
-		},
-		{
-			name: 'output',
-			type: 'folder-path',
-			description: 'Path to output folder',
-			default: 'output'
-		},
-		{
-			name: 'frontmatter-fields',
-			type: 'list',
-			description: 'Frontmatter fields',
-			default: 'title,date,categories,tags,coverImage,draft'
-		},
-		{
-			name: 'request-delay',
-			type: 'integer',
-			description: 'Delay between image file requests',
-			default: 500
-		},
-		{
-			name: 'write-delay',
-			type: 'integer',
-			description: 'Delay between writing markdown files',
-			default: 25
-		},
-		{
-			name: 'timezone',
-			type: 'string',
-			description: 'Timezone to apply to date',
-			default: 'utc'
-		},
-		{
-			name: 'include-time',
-			type: 'boolean',
-			description: 'Include time with frontmatter date',
-			default: false
-		},
-		{
-			name: 'date-format',
-			type: 'string',
-			description: 'Frontmatter date format string',
-			default: ''
-		},
-		{
-			name: 'quote-date',
-			type: 'boolean',
-			description: 'Wrap frontmatter date in quotes',
-			default: false
-		},
-		{
-			name: 'strict-ssl',
-			type: 'boolean',
-			description: 'Use strict SSL',
-			default: true
-		}
-	];
+        {
+            name: "input",
+            type: "file-path",
+            description: "Path to WordPress export file",
+            default: "export.xml",
+            prompt: inquirer.input,
+        },
+        {
+            name: "post-folders",
+            type: "boolean",
+            description: "Put each post into its own folder",
+            default: true,
+            choices: [
+                {
+                    name: "Yes",
+                    value: true,
+                },
+                {
+                    name: "No",
+                    value: false,
+                },
+            ],
+            isPathQuestion: true,
+            prompt: inquirer.select,
+        },
+        {
+            name: "prefix-date",
+            type: "boolean",
+            description: "Add date prefix to posts",
+            default: false,
+            choices: [
+                {
+                    name: "Yes",
+                    value: true,
+                },
+                {
+                    name: "No",
+                    value: false,
+                },
+            ],
+            isPathQuestion: true,
+            prompt: inquirer.select,
+        },
+        {
+            name: "date-folders",
+            type: "choice",
+            description: "Organize posts into date folders",
+            default: "none",
+            choices: [
+                {
+                    name: "Year folders",
+                    value: "year",
+                },
+                {
+                    name: "Year and month folders",
+                    value: "year-month",
+                },
+                {
+                    name: "No",
+                    value: "none",
+                },
+            ],
+            isPathQuestion: true,
+            prompt: inquirer.select,
+        },
+        {
+            name: "save-images",
+            type: "choice",
+            description: "Save images",
+            default: "all",
+            choices: [
+                {
+                    name: "Images attached to posts",
+                    value: "attached",
+                },
+                {
+                    name: "Images scraped from post body content",
+                    value: "scraped",
+                },
+                {
+                    name: "All Images",
+                    value: "all",
+                },
+                {
+                    name: "No",
+                    value: "none",
+                },
+            ],
+            prompt: inquirer.select,
+        },
+        {
+            name: "wizard",
+            type: "boolean",
+            description: "Use wizard",
+            default: true,
+        },
+        {
+            name: "output",
+            type: "folder-path",
+            description: "Path to output folder",
+            default: "output",
+        },
+        {
+            name: "frontmatter-fields",
+            type: "list",
+            description: "Frontmatter fields",
+            default:
+                "title,date,categories,tags,coverImage,draft",
+        },
+        {
+            name: "request-delay",
+            type: "integer",
+            description: "Delay between image file requests",
+            default: 500,
+        },
+        {
+            name: "write-delay",
+            type: "integer",
+            description: "Delay between writing markdown files",
+            default: 25,
+        },
+        {
+            name: "timezone",
+            type: "string",
+            description: "Timezone to apply to date",
+            default: "utc",
+        },
+        {
+            name: "include-time",
+            type: "boolean",
+            description: "Include time with frontmatter date",
+            default: false,
+        },
+        {
+            name: "date-format",
+            type: "string",
+            description: "Frontmatter date format string",
+            default: "",
+        },
+        {
+            name: "quote-date",
+            type: "boolean",
+            description: "Wrap frontmatter date in quotes",
+            default: false,
+        },
+        {
+            name: "strict-ssl",
+            type: "boolean",
+            description: "Use strict SSL",
+            default: true,
+        },
+    ];
 }

--- a/src/questions.js
+++ b/src/questions.js
@@ -4,156 +4,155 @@ export function load() {
 	// questions with a description are displayed in command line help
 	// questions with a prompt are included in the wizard (if not set on the command line)
 	return [
-        {
-            name: "input",
-            type: "file-path",
-            description: "Path to WordPress export file",
-            default: "export.xml",
-            prompt: inquirer.input,
-        },
-        {
-            name: "post-folders",
-            type: "boolean",
-            description: "Put each post into its own folder",
-            default: true,
-            choices: [
-                {
-                    name: "Yes",
-                    value: true,
-                },
-                {
-                    name: "No",
-                    value: false,
-                },
-            ],
-            isPathQuestion: true,
-            prompt: inquirer.select,
-        },
-        {
-            name: "prefix-date",
-            type: "boolean",
-            description: "Add date prefix to posts",
-            default: false,
-            choices: [
-                {
-                    name: "Yes",
-                    value: true,
-                },
-                {
-                    name: "No",
-                    value: false,
-                },
-            ],
-            isPathQuestion: true,
-            prompt: inquirer.select,
-        },
-        {
-            name: "date-folders",
-            type: "choice",
-            description: "Organize posts into date folders",
-            default: "none",
-            choices: [
-                {
-                    name: "Year folders",
-                    value: "year",
-                },
-                {
-                    name: "Year and month folders",
-                    value: "year-month",
-                },
-                {
-                    name: "No",
-                    value: "none",
-                },
-            ],
-            isPathQuestion: true,
-            prompt: inquirer.select,
-        },
-        {
-            name: "save-images",
-            type: "choice",
-            description: "Save images",
-            default: "all",
-            choices: [
-                {
-                    name: "Images attached to posts",
-                    value: "attached",
-                },
-                {
-                    name: "Images scraped from post body content",
-                    value: "scraped",
-                },
-                {
-                    name: "All Images",
-                    value: "all",
-                },
-                {
-                    name: "No",
-                    value: "none",
-                },
-            ],
-            prompt: inquirer.select,
-        },
-        {
-            name: "wizard",
-            type: "boolean",
-            description: "Use wizard",
-            default: true,
-        },
-        {
-            name: "output",
-            type: "folder-path",
-            description: "Path to output folder",
-            default: "output",
-        },
-        {
-            name: "frontmatter-fields",
-            type: "list",
-            description: "Frontmatter fields",
-            default:
-                "title,date,categories,tags,coverImage,draft",
-        },
-        {
-            name: "request-delay",
-            type: "integer",
-            description: "Delay between image file requests",
-            default: 500,
-        },
-        {
-            name: "write-delay",
-            type: "integer",
-            description: "Delay between writing markdown files",
-            default: 25,
-        },
-        {
-            name: "timezone",
-            type: "string",
-            description: "Timezone to apply to date",
-            default: "utc",
-        },
-        {
-            name: "include-time",
-            type: "boolean",
-            description: "Include time with frontmatter date",
-            default: false,
-        },
-        {
-            name: "date-format",
-            type: "string",
-            description: "Frontmatter date format string",
-            default: "",
-        },
-        {
-            name: "quote-date",
-            type: "boolean",
-            description: "Wrap frontmatter date in quotes",
-            default: false,
-        },
-        {
-            name: "strict-ssl",
-            type: "boolean",
-            description: "Use strict SSL",
-            default: true,
-        },
-    ];
+		{
+			name: 'input',
+			type: 'file-path',
+			description: 'Path to WordPress export file',
+			default: 'export.xml',
+			prompt: inquirer.input
+		},
+		{
+			name: 'post-folders',
+			type: 'boolean',
+			description: 'Put each post into its own folder',
+			default: true,
+			choices: [
+				{
+					name: 'Yes',
+					value: true
+				},
+				{
+					name: 'No',
+					value: false
+				}
+			],
+			isPathQuestion: true,
+			prompt: inquirer.select
+		},
+		{
+			name: 'prefix-date',
+			type: 'boolean',
+			description: 'Add date prefix to posts',
+			default: false,
+			choices: [
+				{
+					name: 'Yes',
+					value: true
+				},
+				{
+					name: 'No',
+					value: false
+				}
+			],
+			isPathQuestion: true,
+			prompt: inquirer.select
+		},
+		{
+			name: 'date-folders',
+			type: 'choice',
+			description: 'Organize posts into date folders',
+			default: 'none',
+			choices: [
+				{
+					name: 'Year folders',
+					value: 'year'
+				},
+				{
+					name: 'Year and month folders',
+					value: 'year-month'
+				},
+				{
+					name: 'No',
+					value: 'none'
+				}
+			],
+			isPathQuestion: true,
+			prompt: inquirer.select
+		},
+		{
+			name: 'save-images',
+			type: 'choice',
+			description: 'Save images',
+			default: 'all',
+			choices: [
+				{
+					name: 'Images attached to posts',
+					value: 'attached'
+				},
+				{
+					name: 'Images scraped from post body content',
+					value: 'scraped'
+				},
+				{
+					name: 'All Images',
+					value: 'all'
+				},
+				{
+					name: 'No',
+					value: 'none'
+				}
+			],
+			prompt: inquirer.select
+		},
+		{
+			name: 'wizard',
+			type: 'boolean',
+			description: 'Use wizard',
+			default: true
+		},
+		{
+			name: 'output',
+			type: 'folder-path',
+			description: 'Path to output folder',
+			default: 'output'
+		},
+		{
+			name: 'frontmatter-fields',
+			type: 'list',
+			description: 'Frontmatter fields',
+			default: 'title,date,categories,tags,coverImage,draft'
+		},
+		{
+			name: 'request-delay',
+			type: 'integer',
+			description: 'Delay between image file requests',
+			default: 500
+		},
+		{
+			name: 'write-delay',
+			type: 'integer',
+			description: 'Delay between writing markdown files',
+			default: 25
+		},
+		{
+			name: 'timezone',
+			type: 'string',
+			description: 'Timezone to apply to date',
+			default: 'utc'
+		},
+		{
+			name: 'include-time',
+			type: 'boolean',
+			description: 'Include time with frontmatter date',
+			default: false
+		},
+		{
+			name: 'date-format',
+			type: 'string',
+			description: 'Frontmatter date format string',
+			default: ''
+		},
+		{
+			name: 'quote-date',
+			type: 'boolean',
+			description: 'Wrap frontmatter date in quotes',
+			default: false
+		},
+		{
+			name: 'strict-ssl',
+			type: 'boolean',
+			description: 'Use strict SSL',
+			default: true
+		}
+	];
 }

--- a/src/shared.js
+++ b/src/shared.js
@@ -71,6 +71,10 @@ export function buildPostPath(post, overrideConfig) {
 	return path.join(...pathSegments);
 }
 
+export function getOutputPath(filename) {
+	return path.join(config.output, filename);
+}
+
 export function getFilenameFromUrl(url) {
 	let filename = url.split('/').slice(-1)[0];
 	

--- a/src/writer.js
+++ b/src/writer.js
@@ -14,6 +14,7 @@ export async function writeFilesPromise(posts) {
 }
 
 async function writeJSONFile(posts) {
+	shared.logHeading(`Saving posts data as 'posts.json'`);
 	const jsonData = JSON.stringify(posts, undefined, 4);
 	const filename = shared.getOutputPath("posts.json");
 	writeFile(filename, jsonData);

--- a/src/writer.js
+++ b/src/writer.js
@@ -8,8 +8,15 @@ import path from 'path';
 import * as shared from './shared.js';
 
 export async function writeFilesPromise(posts) {
+	await writeJSONFile(posts);
 	await writeMarkdownFilesPromise(posts);
 	await writeImageFilesPromise(posts);
+}
+
+async function writeJSONFile(posts) {
+	const jsonData = JSON.stringify(posts);
+	const filename = shared.getOutputPath("posts.json");
+	writeFile(filename, jsonData);
 }
 
 async function processPayloadsPromise(payloads, loadFunc) {

--- a/src/writer.js
+++ b/src/writer.js
@@ -14,7 +14,7 @@ export async function writeFilesPromise(posts) {
 }
 
 async function writeJSONFile(posts) {
-	const jsonData = JSON.stringify(posts);
+	const jsonData = JSON.stringify(posts, undefined, 4);
 	const filename = shared.getOutputPath("posts.json");
 	writeFile(filename, jsonData);
 }


### PR DESCRIPTION
this PR adds :
- *postmeta* added to post objects
- parsed posts data saved as json
- use `meta` (postmeta) fields in front-matter
    use the *dot-notation* as following to access any available post-**meta** fields:

```bash
npx wordpress-export-to-markdown  --frontmatter-fields "title,date,categories,tags,coverImage,draft,meta.YOUR_CUSTOM_FIELDNAME:maybeAliased"
```