### PR TITLE
Add a 'year-month-day' option to date-folders.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,12 +81,13 @@ Allowed values:
 --date-folders=none
 ```
 
-If and how output is organized into folders based on date.
+If and how output is organized into folders based on date.  This won't happen for posts with no date (for example, an undated draft post).
 
 Allowed values:
 
-- `year` - Output is organized into folders by year. This won't happen for posts with no date (for example, an undated draft post).
-- `year‑month` - Output is organized into folders by year, then into nested folders by month. Again, for posts with no date, this won't happen.
+- `year` - Output is organized into folders by year. 
+- `year‑month` - Output is organized into folders by year, then into nested folders by month.
+- `year‑month‑day` - Output is organized into folders by year, then nested by month, then nested by the day of the month.
 - `none` - No date folders are created.
 
 ### Save images?

--- a/src/questions.js
+++ b/src/questions.js
@@ -62,6 +62,10 @@ export function load() {
 					value: 'year-month'
 				},
 				{
+					name: 'Year, month and day folders',
+					value: 'year-month-day'
+				},
+				{
 					name: 'No',
 					value: 'none'
 				}

--- a/src/shared.js
+++ b/src/shared.js
@@ -44,12 +44,14 @@ export function buildPostPath(post, overrideConfig) {
 
 	// add folders for date year/month as appropriate
 	if (post.date) {
-		if (pathConfig.dateFolders === 'year' || pathConfig.dateFolders === 'year-month') {
+		if (pathConfig.dateFolders === 'year' || pathConfig.dateFolders === 'year-month' || pathConfig.dateFolders === 'year-month-day') {
 			pathSegments.push(post.date.toFormat('yyyy'));
 		}
-
-		if (pathConfig.dateFolders === 'year-month') {
+		if (pathConfig.dateFolders === 'year-month' || pathConfig.dateFolders === 'year-month-day') {
 			pathSegments.push(post.date.toFormat('LL'));
+		}
+		if (pathConfig.dateFolders === 'year-month-day') {
+			pathSegments.push(post.date.toFormat('dd'));
 		}
 	}
 


### PR DESCRIPTION
This adds one more optional level of hierarchy to the nested date folders, allowing you to include the day of the month in the output path.

Syntax:
`--date-folders=year-month-day`
