### PR TITLE
Allow the post ID to be used instead of the slug

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,20 @@ Allowed values:
 - `true` - Prepend the date, in the format `<year>-<month>-<day>`. Nothing will be prepended if there is no date (for example, an undated draft post).
 - `false` - Don't prepend the date.
 
+### Use post ID instead of slug?
+
+```
+--use-id=true
+```
+
+Whether to use the post ID instead of the post slug when naming post folders or files.  
+
+Note that if the slug is included in the frontmatter, some site generators (such as Hugo) will still use it when generating *their* paths, so you may wish to exclude `slug` from the frontmatter, or rename it to something else using the `--frontmatter-fields` option, for example::
+
+```
+--frontmatter-fields=title,date,id,slug:wpSlug
+```
+
 ### Organize posts into date folders?
 
 ```

--- a/src/questions.js
+++ b/src/questions.js
@@ -48,6 +48,24 @@ export function load() {
 			prompt: inquirer.select
 		},
 		{
+			name: 'use-id',
+			type: 'boolean',
+			description: 'Use post ID instead of slug when naming files or folders',
+			default: false,
+			choices: [
+				{
+					name: 'Yes',
+					value: true
+				},
+				{
+					name: 'No',
+					value: false
+				}
+			],
+			isPathQuestion: true,
+			prompt: inquirer.select
+		},
+		{
 			name: 'date-folders',
 			type: 'choice',
 			description: 'Organize posts into date folders',

--- a/src/shared.js
+++ b/src/shared.js
@@ -55,6 +55,10 @@ export function buildPostPath(post, overrideConfig) {
 
 	// get slug with fallback
 	let slug = getSlugWithFallback(post);
+	// use ID instead of slug if specified
+	if (pathConfig.useId) {
+		slug = post.id.toString();
+	}
 
 	// prepend date to slug as appropriate
 	if (pathConfig.prefixDate && post.date) {


### PR DESCRIPTION
This adds a `--use-id` option, which will cause the post ID to be used instead of the slug when creating file or folder names.

(My Wordpress site uses URLs of the form `/archives/2025/12/07/13426/`, and I need to preserve these, so I wanted a folder per post, but no use of the slug.)

I've added an additional comment to the README because Hugo, at least, will still use the slug if it's present in the front matter, which can be confusing!  Fortunately, the renaming facility in the `--frontmatter-fields` option deals with this nicely - thanks!
