### PR TITLE
Feature: add custom taxonomy support and taxonomy metadata export

### DIFF
--- a/app.js
+++ b/app.js
@@ -23,10 +23,10 @@ import * as writer from './src/writer.js';
 	await intake.getConfig();
 
 	// parse data from XML and do Markdown translations
-	const posts = await parser.parseFilePromise()
+	const { posts, taxonomies } = await parser.parseFilePromise()
 
 	// write files and download images
-	await writer.writeFilesPromise(posts);
+	await writer.writeFilesPromise(posts, taxonomies);
 
 	// happy goodbye
 	console.log('\nAll done!');

--- a/src/parser.js
+++ b/src/parser.js
@@ -236,29 +236,34 @@ function populateFrontmatter(posts) {
 	});
 }
 
+function buildTaxonomyEntry({ slug, name, parent, description }) {
+	const entry = { slug, name };
+	if (parent) entry.parent = parent;
+	if (description) entry.description = description;
+	return entry;
+}
+
 function collectTaxonomyMetadata(channel) {
 	const taxonomies = {};
 
 	// channel-level <wp:category> elements (stripped to 'category')
 	const wpCategories = channel.children('category');
 	if (wpCategories.length > 0) {
-		taxonomies.category = wpCategories.map((cat) => ({
-			termId: parseInt(cat.optionalChildValue('term_id')),
+		taxonomies.category = wpCategories.map((cat) => buildTaxonomyEntry({
 			slug: cat.optionalChildValue('category_nicename'),
 			name: cat.optionalChildValue('cat_name'),
-			parent: cat.optionalChildValue('category_parent') || null,
-			description: cat.optionalChildValue('category_description') || null
+			parent: cat.optionalChildValue('category_parent'),
+			description: cat.optionalChildValue('category_description')
 		}));
 	}
 
 	// channel-level <wp:tag> elements (stripped to 'tag')
 	const wpTags = channel.children('tag');
 	if (wpTags.length > 0) {
-		taxonomies.post_tag = wpTags.map((tag) => ({
-			termId: parseInt(tag.optionalChildValue('term_id')),
+		taxonomies.post_tag = wpTags.map((tag) => buildTaxonomyEntry({
 			slug: tag.optionalChildValue('tag_slug'),
 			name: tag.optionalChildValue('tag_name'),
-			description: tag.optionalChildValue('tag_description') || null
+			description: tag.optionalChildValue('tag_description')
 		}));
 	}
 
@@ -272,13 +277,12 @@ function collectTaxonomyMetadata(channel) {
 		if (!taxonomies[taxonomy]) {
 			taxonomies[taxonomy] = [];
 		}
-		taxonomies[taxonomy].push({
-			termId: parseInt(term.optionalChildValue('term_id')),
+		taxonomies[taxonomy].push(buildTaxonomyEntry({
 			slug: term.optionalChildValue('term_slug'),
 			name: term.optionalChildValue('term_name'),
-			parent: term.optionalChildValue('term_parent') || null,
-			description: term.optionalChildValue('term_description') || null
-		});
+			parent: term.optionalChildValue('term_parent'),
+			description: term.optionalChildValue('term_description')
+		}));
 	});
 
 	return taxonomies;

--- a/src/parser.js
+++ b/src/parser.js
@@ -10,7 +10,10 @@ export async function parseFilePromise() {
 	shared.logHeading('Parsing');
 	const content = await fs.promises.readFile(shared.config.input, 'utf8');
 	const rssData = await data.load(content);
-	const allPostData = rssData.child('channel').children('item');
+	const channel = rssData.child('channel');
+	const allPostData = channel.children('item');
+
+	const taxonomies = collectTaxonomyMetadata(channel);
 
 	const postTypes = getPostTypes(allPostData);
 	const posts = collectPosts(allPostData, postTypes);
@@ -26,7 +29,7 @@ export async function parseFilePromise() {
 	mergeImagesIntoPosts(images, posts);
 	populateFrontmatter(posts);
 
-	return posts;
+	return { posts, taxonomies };
 }
 
 function getPostTypes(allPostData) {
@@ -85,6 +88,18 @@ function collectPosts(allPostData, postTypes) {
 }
 
 function buildPost(data) {
+	// collect custom taxonomy term slugs keyed by taxonomy slug
+	const customTaxonomies = {};
+	data.children('category')
+		.filter((cat) => cat.attribute('domain') !== 'category' && cat.attribute('domain') !== 'post_tag')
+		.forEach((cat) => {
+			const domain = cat.attribute('domain');
+			if (!customTaxonomies[domain]) {
+				customTaxonomies[domain] = [];
+			}
+			customTaxonomies[domain].push(decodeURIComponent(cat.attribute('nicename')));
+		});
+
 	return {
 		// full raw post data
 		data,
@@ -102,7 +117,10 @@ function buildPost(data) {
 
 		// these are possibly set later in mergeImagesIntoPosts()
 		coverImage: undefined,
-		imageUrls: []
+		imageUrls: [],
+
+		// custom taxonomy terms keyed by taxonomy slug
+		customTaxonomies
 	};
 }
 
@@ -204,7 +222,62 @@ function populateFrontmatter(posts) {
 
 			post.frontmatter[alias ?? key] = frontmatterGetter(post);
 		});
+
+		// inject custom taxonomy slugs into frontmatter, each taxonomy as its own field
+		Object.entries(post.customTaxonomies).forEach(([domain, slugs]) => {
+			if (slugs.length > 0) {
+				post.frontmatter[domain] = slugs;
+			}
+		});
 	});
+}
+
+function collectTaxonomyMetadata(channel) {
+	const taxonomies = {};
+
+	// channel-level <wp:category> elements (stripped to 'category')
+	const wpCategories = channel.children('category');
+	if (wpCategories.length > 0) {
+		taxonomies.category = wpCategories.map((cat) => ({
+			termId: parseInt(cat.optionalChildValue('term_id')),
+			slug: cat.optionalChildValue('category_nicename'),
+			name: cat.optionalChildValue('cat_name'),
+			parent: cat.optionalChildValue('category_parent') || null,
+			description: cat.optionalChildValue('category_description') || null
+		}));
+	}
+
+	// channel-level <wp:tag> elements (stripped to 'tag')
+	const wpTags = channel.children('tag');
+	if (wpTags.length > 0) {
+		taxonomies.post_tag = wpTags.map((tag) => ({
+			termId: parseInt(tag.optionalChildValue('term_id')),
+			slug: tag.optionalChildValue('tag_slug'),
+			name: tag.optionalChildValue('tag_name'),
+			description: tag.optionalChildValue('tag_description') || null
+		}));
+	}
+
+	// channel-level <wp:term> elements (stripped to 'term') — custom taxonomies
+	const wpTerms = channel.children('term');
+	wpTerms.forEach((term) => {
+		const taxonomy = term.optionalChildValue('term_taxonomy');
+		if (!taxonomy || taxonomy === 'category' || taxonomy === 'post_tag') {
+			return;
+		}
+		if (!taxonomies[taxonomy]) {
+			taxonomies[taxonomy] = [];
+		}
+		taxonomies[taxonomy].push({
+			termId: parseInt(term.optionalChildValue('term_id')),
+			slug: term.optionalChildValue('term_slug'),
+			name: term.optionalChildValue('term_name'),
+			parent: term.optionalChildValue('term_parent') || null,
+			description: term.optionalChildValue('term_description') || null
+		});
+	});
+
+	return taxonomies;
 }
 
 function prioritizePostType(postTypes, postType) {

--- a/src/parser.js
+++ b/src/parser.js
@@ -226,7 +226,7 @@ function populateFrontmatter(posts) {
 		// inject custom taxonomy slugs into frontmatter, each taxonomy as its own field
 		Object.entries(post.customTaxonomies).forEach(([domain, slugs]) => {
 			if (slugs.length > 0) {
-				if (post.frontmatter.hasOwnProperty(domain)) {
+				if (Object.hasOwn(post.frontmatter, domain)) {
 					console.warn(`⚠️  Skipping custom taxonomy '${domain}' on post '${post.slug}' because it conflicts with an existing frontmatter field.`);
 					return;
 				}

--- a/src/parser.js
+++ b/src/parser.js
@@ -226,6 +226,10 @@ function populateFrontmatter(posts) {
 		// inject custom taxonomy slugs into frontmatter, each taxonomy as its own field
 		Object.entries(post.customTaxonomies).forEach(([domain, slugs]) => {
 			if (slugs.length > 0) {
+				if (post.frontmatter.hasOwnProperty(domain)) {
+					console.warn(`⚠️  Skipping custom taxonomy '${domain}' on post '${post.slug}' because it conflicts with an existing frontmatter field.`);
+					return;
+				}
 				post.frontmatter[domain] = slugs;
 			}
 		});

--- a/src/parser.js
+++ b/src/parser.js
@@ -224,15 +224,17 @@ function populateFrontmatter(posts) {
 		});
 
 		// inject custom taxonomy slugs into frontmatter, each taxonomy as its own field
-		Object.entries(post.customTaxonomies).forEach(([domain, slugs]) => {
-			if (slugs.length > 0) {
-				if (Object.hasOwn(post.frontmatter, domain)) {
-					console.warn(`⚠️  Skipping custom taxonomy '${domain}' on post '${post.slug}' because it conflicts with an existing frontmatter field.`);
-					return;
+		if (shared.config.includeCustomTaxonomies) {
+			Object.entries(post.customTaxonomies).forEach(([domain, slugs]) => {
+				if (slugs.length > 0) {
+					if (Object.hasOwn(post.frontmatter, domain)) {
+						console.warn(`⚠️  Skipping custom taxonomy '${domain}' on post '${post.slug}' because it conflicts with an existing frontmatter field.`);
+						return;
+					}
+					post.frontmatter[domain] = slugs;
 				}
-				post.frontmatter[domain] = slugs;
-			}
-		});
+			});
+		}
 	});
 }
 

--- a/src/questions.js
+++ b/src/questions.js
@@ -113,6 +113,40 @@ export function load() {
 			default: 'title,date,categories,tags,coverImage,draft'
 		},
 		{
+			name: 'include-custom-taxonomies',
+			type: 'boolean',
+			description: 'Include custom taxonomies in post frontmatter',
+			default: true,
+			choices: [
+				{
+					name: 'Yes',
+					value: true
+				},
+				{
+					name: 'No',
+					value: false
+				}
+			],
+			prompt: inquirer.select
+		},
+		{
+			name: 'save-taxonomy-data',
+			type: 'boolean',
+			description: 'Save taxonomy data to JSON files (categories, tags, and custom taxonomies if enabled)',
+			default: true,
+			choices: [
+				{
+					name: 'Yes',
+					value: true
+				},
+				{
+					name: 'No',
+					value: false
+				}
+			],
+			prompt: inquirer.select
+		},
+		{
 			name: 'request-delay',
 			type: 'integer',
 			description: 'Delay between image file requests',

--- a/src/writer.js
+++ b/src/writer.js
@@ -7,9 +7,10 @@ import * as luxon from 'luxon';
 import path from 'path';
 import * as shared from './shared.js';
 
-export async function writeFilesPromise(posts) {
+export async function writeFilesPromise(posts, taxonomies) {
 	await writeMarkdownFilesPromise(posts);
 	await writeImageFilesPromise(posts);
+	await writeTaxonomyFilesPromise(taxonomies);
 }
 
 async function processPayloadsPromise(payloads, loadFunc) {
@@ -186,6 +187,24 @@ function logSavingMessage(things, existingCount, remainingCount) {
 		console.log(`All ${existingCount} ${things} already saved.`);
 	} else {
 		console.log(`${existingCount} ${things} already saved, ${remainingCount} remaining.`);
+	}
+}
+
+async function writeTaxonomyFilesPromise(taxonomies) {
+	shared.logHeading('Saving taxonomy data');
+
+	const entries = Object.entries(taxonomies);
+	if (entries.length === 0) {
+		console.log('No taxonomy data to save.');
+		return;
+	}
+
+	const taxonomyDir = path.join(shared.config.output, 'taxonomies');
+	for (const [taxonomyName, terms] of entries) {
+		const filePath = path.join(taxonomyDir, `${taxonomyName}.json`);
+		const content = JSON.stringify(terms, null, '\t');
+		await writeFile(filePath, content);
+		console.log(`${chalk.green('✓')} ${chalk.gray('[taxonomy]')} ${taxonomyName}.json (${terms.length} terms)`);
 	}
 }
 

--- a/src/writer.js
+++ b/src/writer.js
@@ -10,7 +10,9 @@ import * as shared from './shared.js';
 export async function writeFilesPromise(posts, taxonomies) {
 	await writeMarkdownFilesPromise(posts);
 	await writeImageFilesPromise(posts);
-	await writeTaxonomyFilesPromise(taxonomies);
+	if (shared.config.saveTaxonomyData) {
+		await writeTaxonomyFilesPromise(taxonomies);
+	}
 }
 
 async function processPayloadsPromise(payloads, loadFunc) {
@@ -193,7 +195,14 @@ function logSavingMessage(things, existingCount, remainingCount) {
 async function writeTaxonomyFilesPromise(taxonomies) {
 	shared.logHeading('Saving taxonomy data');
 
-	const entries = Object.entries(taxonomies);
+	const builtInTaxonomies = ['category', 'post_tag'];
+	const filteredTaxonomies = Object.fromEntries(
+		Object.entries(taxonomies).filter(([name]) =>
+			builtInTaxonomies.includes(name) || shared.config.includeCustomTaxonomies
+		)
+	);
+
+	const entries = Object.entries(filteredTaxonomies);
 	if (entries.length === 0) {
 		console.log('No taxonomy data to save.');
 		return;


### PR DESCRIPTION
## Summary

This adds two related features useful for migrating WordPress sites to static site generators like Astro:

### 1. Custom taxonomies in post frontmatter

Posts with custom taxonomies (e.g. `destination`, `cuisine`, `location`) now have those terms automatically included as frontmatter fields alongside the standard `categories` and `tags`.

Example output:
```yaml
categories:
  - "travel"
destination:
  - "japan"
  - "taiwan"
```

If a custom taxonomy domain name conflicts with an existing frontmatter field, it is skipped and a warning is printed rather than silently overwriting it.

### 2. Taxonomy metadata JSON export

Channel-level taxonomy definitions are exported to `<output>/taxonomies/` as JSON files — one per taxonomy (`category.json`, `post_tag.json`, and one for each custom taxonomy). Each entry includes `slug`, `name`, and optionally `parent` and `description` when present.

This is useful for rendering taxonomy pages with display names instead of raw slugs.

Example `category.json`:
```json
[
  { "slug": "web-development", "name": "Web Development" },
  { "slug": "travel", "name": "Travel", "parent": "lifestyle" }
]
```

### New options

| Option | Default | Description |
|---|---|---|
| `--include-custom-taxonomies` | `true` | Include custom taxonomy terms in post frontmatter |
| `--save-taxonomy-data` | `true` | Export taxonomy metadata to JSON files |

When `--include-custom-taxonomies` is `false`, custom taxonomy JSON files are also excluded from the export (only `category.json` and `post_tag.json` are written).