### PR TITLE
Fix invalid triple-slash links to prevent SSG build crashes

### DIFF
--- a/src/translator.js
+++ b/src/translator.js
@@ -114,13 +114,8 @@ export function getPostContent(content) {
 	// without mucking up content inside of other elements (like <code> blocks)
 	content = content.replace(/(\r?\n){2}/g, '\n<div></div>\n');
 
-	// Detect Windows Registry keys and technical logs in <strong> or <span> tags
-	// and wrap them in <pre> tags so Turndown converts them to code blocks
-	content = content.replace(/<(strong|span)[^>]*>\s*(HKLM|HKCU|HKEY_[A-Z_]+|Event ID\s*:)[^<]+<\/\1>/gi, '<pre>$&</pre>');
-
 	// Strip out completely invalid links like href="///" that cause SSG builds (like Hugo) to crash
 	content = content.replace(/<a[^>]*href="\/\/\/".*?>(.*?)<\/a>/g, '$1');
-
 
 	if (shared.config.saveImages === 'scraped' || shared.config.saveImages === 'all') {
 		// writeImageFile() will save all content images to a relative /images

--- a/src/translator.js
+++ b/src/translator.js
@@ -114,6 +114,14 @@ export function getPostContent(content) {
 	// without mucking up content inside of other elements (like <code> blocks)
 	content = content.replace(/(\r?\n){2}/g, '\n<div></div>\n');
 
+	// Detect Windows Registry keys and technical logs in <strong> or <span> tags
+	// and wrap them in <pre> tags so Turndown converts them to code blocks
+	content = content.replace(/<(strong|span)[^>]*>\s*(HKLM|HKCU|HKEY_[A-Z_]+|Event ID\s*:)[^<]+<\/\1>/gi, '<pre>$&</pre>');
+
+	// Strip out completely invalid links like href="///" that cause SSG builds (like Hugo) to crash
+	content = content.replace(/<a[^>]*href="\/\/\/".*?>(.*?)<\/a>/g, '$1');
+
+
 	if (shared.config.saveImages === 'scraped' || shared.config.saveImages === 'all') {
 		// writeImageFile() will save all content images to a relative /images
 		// folder so update references in post content to match


### PR DESCRIPTION
Stripping invalid links like href='///' to prevent SSGs like Hugo from crashing by attempting to publish the root directory. Additionally, automatically wrapping common Windows technical logs (HKLM, Event ID) in <pre> tags ensures Turndown correctly formats them as code blocks.